### PR TITLE
Fix broken build script for Lab 05 example

### DIFF
--- a/05_SYCL_Local_Memory_And_Atomics/run_matrixmul_16x16.sh
+++ b/05_SYCL_Local_Memory_And_Atomics/run_matrixmul_16x16.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
-/bin/echo "##" $(whoami) is compiling SYCL_Essentials Module12 -- SYCL Atomics Local Memory - 4 of 5 matrixmul_16x16_localmem.cpp
-icpx -fsycl lab/matrixmul_16x16_localmem.cpp 
+/bin/echo "##" $(whoami) is compiling SYCL_Essentials Module12 -- SYCL Atomics Local Memory - 4 of 5 matrixmul_16x16.cpp
+icpx -fsycl lab/matrixmul_16x16.cpp 
 if [ $? -eq 0 ]; then ./a.out; fi
 


### PR DESCRIPTION
This fixes the building of a currently mismatched example in the notebook, causing it to additionally fail prematurely when run in-order.